### PR TITLE
Add support for starting a third service

### DIFF
--- a/src/utils-spec.js
+++ b/src/utils-spec.js
@@ -71,6 +71,23 @@ describe('utils', () => {
       snapshot({ args, parsed })
     })
 
+    it('allows 7 arguments', () => {
+      const args = [
+        'start',
+        '6000',
+        'start:db',
+        '6005',
+        'start:web',
+        '6010',
+        'test'
+      ]
+      const parsed = getArguments(args)
+      debug('from %o', args)
+      debug('parsed %o', parsed)
+      debug('services %o', parsed.services)
+      snapshot({ args, parsed })
+    })
+
     it('determines NPM script for each command', () => {
       sandbox.stub(utils, 'isPackageScriptName').returns(true)
       const args = ['startA', '6000', 'startB', '6010', 'testC']

--- a/src/utils.js
+++ b/src/utils.js
@@ -87,6 +87,23 @@ const getArguments = cliArgs => {
     services.push(secondService)
 
     test = cliArgs[4]
+  } else if (cliArgs.length === 7) {
+    service.start = cliArgs[0]
+    service.url = normalizeUrl(cliArgs[1])
+
+    const secondService = {
+      start: cliArgs[2],
+      url: normalizeUrl(cliArgs[3])
+    }
+    services.push(secondService)
+
+    const thirdService = {
+      start: cliArgs[4],
+      url: normalizeUrl(cliArgs[5])
+    }
+    services.push(thirdService)
+
+    test = cliArgs[6]
   } else {
     la(
       cliArgs.length === 3,


### PR DESCRIPTION
`start-server-and-test` can wait for two services but not three services.

Example:
```
start-server-and-test start 6000 start:db 3001 start:web 6010 test
```

